### PR TITLE
Preprocessed dependencies

### DIFF
--- a/example/nb-configuration.xml
+++ b/example/nb-configuration.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project-shared-configuration>
+    <!--
+This file contains additional configuration written by modules in the NetBeans IDE.
+The configuration is intended to be shared among all the users of project and
+therefore it is assumed to be part of version control checkout.
+Without this configuration present, some functionality in the IDE may be limited or fail altogether.
+-->
+    <properties xmlns="http://www.netbeans.org/ns/maven-properties-data/1">
+        <!--
+Properties that influence various parts of the IDE, especially code formatting and the like. 
+You can copy and paste the single properties, into the pom.xml file and the IDE will pick them up.
+That way multiple projects can share the same settings (useful for formatting rules for example).
+Any value defined here will override the pom.xml file value but is only applicable to the current project.
+-->
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.indent-shift-width>4</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.indent-shift-width>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.spaces-per-tab>4</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.spaces-per-tab>
+        <org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.expand-tabs>false</org-netbeans-modules-editor-indent.text.x-java.CodeStyle.project.expand-tabs>
+    </properties>
+</project-shared-configuration>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -13,7 +13,7 @@
 	<name>Roboface Annotation Processor Example</name>
 
 	<properties>
-		<robovm.version>2.3.7</robovm.version>
+		<robovm.version>2.3.10-oec1</robovm.version>
 	</properties>
 
 	<build>

--- a/example/src/main/java/roboface/test/MyFrameworkImplementation.java
+++ b/example/src/main/java/roboface/test/MyFrameworkImplementation.java
@@ -23,6 +23,8 @@
 package roboface.test;
 
 import org.openecard.robovm.annotations.FrameworkObject;
+import roboface.preprocesstest.PreProcessedEnum;
+import roboface.preprocesstest.PreProcessedObject;
 
 
 /**
@@ -56,6 +58,16 @@ public class MyFrameworkImplementation implements MyFrameworkInterface {
 	@Override
 	public SomeArrayEvaluator arrayUsageExample() {
 		return new BasicSomeListEvaluator();
+	}
+
+	@Override
+	public void preProcObj(PreProcessedObject obj) {
+		throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+	}
+
+	@Override
+	public void preProcEnum(PreProcessedEnum enu) {
+		throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
 	}
 
 }

--- a/frameworkexample/pom.xml
+++ b/frameworkexample/pom.xml
@@ -64,6 +64,7 @@
 								<configuration>
 									<includeArtifactIds>roboface-example</includeArtifactIds>
 									<outputDirectory>${basedir}/target/classes/</outputDirectory>
+									<includes>/roboheaders/*</includes>
 								</configuration>
 							</execution>
 						</executions>

--- a/frameworkexample/pom.xml
+++ b/frameworkexample/pom.xml
@@ -13,7 +13,7 @@
 	<packaging>jar</packaging>
 
 	<properties>
-		<robovm.version>2.3.8</robovm.version>
+		<robovm.version>2.3.10-oec1</robovm.version>
 	</properties>
 
 	<dependencies>
@@ -78,6 +78,9 @@
 									<goal>install</goal>
 								</goals>
 								<phase>install</phase>
+								<configuration>
+									<enableBitcode>true</enableBitcode>
+								</configuration>
 							</execution>
 						</executions>
 					</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
 	<modules>
 		<module>annotation</module>
 		<module>processor</module>
+		<module>preprocess-example</module>
 		<module>example</module>
 		<module>roboface-marshaller</module>
 		<module>frameworkexample</module>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,41 @@
 		<url>https://github.com/ecsec/open-ecard</url>
 		<tag>HEAD</tag>
 	</scm>
+	<repositories>
+		<repository>
+			<id>openecard-repos</id>
+			<name>Openecard Repos</name>
+			<url>https://mvn.ecsec.de/repository/openecard-public</url>
+		</repository>
+		<repository>
+			<id>snapshots-repo</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>openecard-repos</id>
+			<url>https://mvn.ecsec.de/repository/openecard-public</url>
+		</pluginRepository>
+		
+		<pluginRepository>
+			<id>snapshots-repo</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
 
 	<distributionManagement>
 		<repository>

--- a/preprocess-example/pom.xml
+++ b/preprocess-example/pom.xml
@@ -8,39 +8,17 @@
 	</parent>
 
 	<groupId>org.openecard.tools</groupId>
-	<artifactId>roboface-example</artifactId>
+	<artifactId>roboface-preprocess-example</artifactId>
 	<packaging>jar</packaging>
-	<name>Roboface Annotation Processor Example</name>
+	<name>Roboface Annotation Processor PreProcessExample</name>
 
 	<properties>
 		<robovm.version>2.3.10-oec1</robovm.version>
 	</properties>
 
 	<build>
-<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-dependency-plugin</artifactId>
-						<version>3.1.1</version>
-						<executions>
-							<execution>
-								<id>copy-framework-classes</id>
-								<goals>
-									<goal>unpack-dependencies</goal>
-								</goals>
-								<configuration>
-									<includeArtifactIds>roboface-pre-process-example</includeArtifactIds>
-									<outputDirectory>${basedir}/target/classes/</outputDirectory>
-									<includes>/roboheaders/*</includes>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-
-</plugins>
 		<pluginManagement>
 			<plugins>
-
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
@@ -56,8 +34,7 @@
 							<proc>org.openecard.robovm.processor.RobofaceProcessor</proc>
 						</annotationProcessors>
 						<compilerArgs>
-							<arg>-Aroboface.headername=my_robo_header.h</arg>
-							<arg>-Aroboface.include.headers=my_robo_pre_header.h</arg>
+							<arg>-Aroboface.headername=my_robo_pre_header.h</arg>
 							<arg>-Aroboface.inheritance.blacklist=java.io.Serializable</arg>
 						</compilerArgs>
 						<debug>true</debug>
@@ -97,11 +74,6 @@
 			<artifactId>robovm-cocoatouch</artifactId>
 			<version>${robovm.version}</version>
 			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>roboface-preprocess-example</artifactId>
-			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/preprocess-example/src/main/java/roboface/preprocesstest/PreProcessedEnum.java
+++ b/preprocess-example/src/main/java/roboface/preprocesstest/PreProcessedEnum.java
@@ -19,31 +19,19 @@
  * you and ecsec GmbH.
  *
  ***************************************************************************/
+package roboface.preprocesstest;
 
-package roboface.test;
-
-import org.openecard.robovm.annotations.FrameworkInterface;
-import roboface.preprocesstest.PreProcessedEnum;
-import roboface.preprocesstest.PreProcessedObject;
+import org.openecard.robovm.annotations.FrameworkEnum;
 
 /**
  *
- * @author Tobias Wich
- * @author Florian Otto
+ * @author Neil Crossley
  */
-@FrameworkInterface
-public interface MyFrameworkInterface {
+@FrameworkEnum
+public enum PreProcessedEnum {
 
-	void fun();
-	void fun(String s);
-	void otherfun(int i);
-
-	void preProcObj(PreProcessedObject obj);
-
-	void preProcEnum(PreProcessedEnum enu);
-
-	SomeInterface getSomeImp();
-	SomeInterface.SomeInnerInterface getSomeInnerImp();
-
-	SomeArrayEvaluator arrayUsageExample();
+	FirstValue,
+	SecondValue,
+	ThirdValue,
+	LastValue,
 }

--- a/preprocess-example/src/main/java/roboface/preprocesstest/PreProcessedObject.java
+++ b/preprocess-example/src/main/java/roboface/preprocesstest/PreProcessedObject.java
@@ -19,31 +19,17 @@
  * you and ecsec GmbH.
  *
  ***************************************************************************/
-
-package roboface.test;
+package roboface.preprocesstest;
 
 import org.openecard.robovm.annotations.FrameworkInterface;
-import roboface.preprocesstest.PreProcessedEnum;
-import roboface.preprocesstest.PreProcessedObject;
 
 /**
  *
- * @author Tobias Wich
- * @author Florian Otto
+ * @author Neil Crossley
  */
 @FrameworkInterface
-public interface MyFrameworkInterface {
+public interface PreProcessedObject {
 
-	void fun();
-	void fun(String s);
-	void otherfun(int i);
+	void method();
 
-	void preProcObj(PreProcessedObject obj);
-
-	void preProcEnum(PreProcessedEnum enu);
-
-	SomeInterface getSomeImp();
-	SomeInterface.SomeInnerInterface getSomeInnerImp();
-
-	SomeArrayEvaluator arrayUsageExample();
 }

--- a/processor/src/main/java/org/openecard/robovm/processor/TypeRegistry.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/TypeRegistry.java
@@ -58,6 +58,12 @@ public class TypeRegistry {
 		if (typeLookup.containsKey(type)) {
 			return typeLookup.get(type);
 		}
+		if (type.tsym.isEnum()) {
+			EnumDescriptor desc = new EnumDescriptor(type.tsym.getSimpleName().toString());
+			typeLookup.put(type, desc);
+			return desc;
+
+		}
 		if (type.isPrimitiveOrVoid()) {
 			PrimitiveDescriptor desc = PrimitiveDescriptor.from(type);
 			typeLookup.put(type, desc);

--- a/roboface-marshaller/pom.xml
+++ b/roboface-marshaller/pom.xml
@@ -13,7 +13,7 @@
 	
 	
 	<properties>
-		<robovm.version>2.3.7</robovm.version>
+		<robovm.version>2.3.10-oec1</robovm.version>
 	</properties>
 	
 	<dependencies>


### PR DESCRIPTION
Fixes a problem which occured if roboface is used multiple times in chained dependencies. 
Roboface recognizes enum types by the defined annotations. If an enum is defined in a dependency this annotation doesn't exist thus roboface isn't aware of it. If it used in a protocol the headers get therefore wrongly generated.

