### PR TITLE
Remove static initializer

### DIFF
--- a/annotation/src/main/java/org/openecard/robovm/annotations/FrameworkObject.java
+++ b/annotation/src/main/java/org/openecard/robovm/annotations/FrameworkObject.java
@@ -39,6 +39,7 @@ public @interface FrameworkObject {
 	/**
 	 * Name of the factory function added to the ObjC header.
 	 */
+	@Deprecated
 	public String factoryMethod();
 
 }

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -29,7 +29,7 @@
 									<goal>unpack-dependencies</goal>
 								</goals>
 								<configuration>
-									<includeArtifactIds>roboface-pre-process-example</includeArtifactIds>
+									<includeArtifactIds>roboface-preprocess-example</includeArtifactIds>
 									<outputDirectory>${basedir}/target/classes/</outputDirectory>
 									<includes>/roboheaders/*</includes>
 								</configuration>

--- a/example/src/main/java/roboface/test/MyDeprecatedInterface.java
+++ b/example/src/main/java/roboface/test/MyDeprecatedInterface.java
@@ -16,11 +16,8 @@ import org.openecard.robovm.annotations.FrameworkInterface;
  * @author Neil Crossley
  */
 @FrameworkInterface
-public interface SomeSimpleInterface {
+@Deprecated
+public interface MyDeprecatedInterface {
 
 	boolean hasMethod();
-
-	@Deprecated
-	void myDeprecatedMethod();
-
 }

--- a/example/src/main/java/roboface/test/MyFrameworkImplementation.java
+++ b/example/src/main/java/roboface/test/MyFrameworkImplementation.java
@@ -48,6 +48,10 @@ public class MyFrameworkImplementation implements MyFrameworkInterface {
 
 	}
 
+	@Deprecated
+	public MyFrameworkImplementation(String someValue, int otherValue) {
+	}
+
 	//some functions
 	public void fun(){
 		System.out.println("fun was called");

--- a/example/src/main/java/roboface/test/MyFrameworkImplementation.java
+++ b/example/src/main/java/roboface/test/MyFrameworkImplementation.java
@@ -36,6 +36,18 @@ import roboface.preprocesstest.PreProcessedObject;
 @FrameworkObject(factoryMethod = "getFrameworkInstance")
 public class MyFrameworkImplementation implements MyFrameworkInterface {
 
+	static {
+		System.out.print("Static initializer of: ");
+		System.out.println(MyFrameworkImplementation.class);
+	}
+
+	public MyFrameworkImplementation() {
+	}
+
+	public MyFrameworkImplementation(String someValue) {
+
+	}
+
 	//some functions
 	public void fun(){
 		System.out.println("fun was called");

--- a/processor/src/main/java/org/openecard/robovm/processor/ClassDescriptor.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/ClassDescriptor.java
@@ -38,12 +38,18 @@ public class ClassDescriptor implements TypeDescriptor, DeclarationDescriptor {
 	private final List<LookupDeclarationDescriptor> extensions;
 	private final List<MethodDescriptor> methods;
 	private final ClassType type;
+	private final boolean deprecated;
 
-	public ClassDescriptor(String ifaceName, List<LookupDeclarationDescriptor> implementing, ClassType type) {
+	public ClassDescriptor(
+			String ifaceName,
+			List<LookupDeclarationDescriptor> implementing,
+			ClassType type,
+			boolean deprecated) {
 		this.objcName = ifaceName;
 		this.methods = new ArrayList<>();
 		this.extensions = implementing;
 		this.type = type;
+		this.deprecated = deprecated;
 	}
 
 	@Override
@@ -53,6 +59,10 @@ public class ClassDescriptor implements TypeDescriptor, DeclarationDescriptor {
 
 	public ClassType getClassType() {
 		return this.type;
+	}
+
+	public boolean isDeprecated() {
+		return this.deprecated;
 	}
 
 	public void addMethod(MethodDescriptor method) {

--- a/processor/src/main/java/org/openecard/robovm/processor/ClassDescriptor.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/ClassDescriptor.java
@@ -32,14 +32,14 @@ import java.util.List;
  * @author Tobias Wich
  * @author Neil Crossley
  */
-public class ProtocolDescriptor implements TypeDescriptor, DeclarationDescriptor {
+public class ClassDescriptor implements TypeDescriptor, DeclarationDescriptor {
 
 	private final String objcName;
 	private final List<LookupDeclarationDescriptor> extensions;
 	private final List<MethodDescriptor> methods;
-	private final IosType type;
+	private final ClassType type;
 
-	public ProtocolDescriptor(String ifaceName, List<LookupDeclarationDescriptor> implementing, IosType type) {
+	public ClassDescriptor(String ifaceName, List<LookupDeclarationDescriptor> implementing, ClassType type) {
 		this.objcName = ifaceName;
 		this.methods = new ArrayList<>();
 		this.extensions = implementing;
@@ -51,7 +51,7 @@ public class ProtocolDescriptor implements TypeDescriptor, DeclarationDescriptor
 		return objcName;
 	}
 
-	public IosType getType() {
+	public ClassType getClassType() {
 		return this.type;
 	}
 
@@ -75,7 +75,7 @@ public class ProtocolDescriptor implements TypeDescriptor, DeclarationDescriptor
 
 	@Override
 	public String getIosType() {
-		return String.format("NSObject<%s> *", this.objcName);
+		return this.getClassType().asReference(this);
 	}
 
 	@Override
@@ -83,8 +83,18 @@ public class ProtocolDescriptor implements TypeDescriptor, DeclarationDescriptor
 		return null;
 	}
 
-	public static enum IosType {
-		Interface,
-		Protocol;
+	public static enum ClassType {
+		Interface("%s *"),
+		Protocol("NSObject<%s> *");
+
+		private final String iosTypeFormat;
+
+		ClassType(String iosTypeFormat){
+			this.iosTypeFormat = iosTypeFormat;
+		}
+
+		public String asReference(DeclarationDescriptor descriptor) {
+			return String.format(iosTypeFormat, descriptor.getObjcName());
+		}
 	}
 }

--- a/processor/src/main/java/org/openecard/robovm/processor/FactoryDefinition.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/FactoryDefinition.java
@@ -27,13 +27,13 @@ package org.openecard.robovm.processor;
  *
  * @author Tobias Wich
  */
-public class ObjectDefinition {
+public class FactoryDefinition {
 
 	private final String javaName;
 	private final String factoryName;
 	private final ClassDescriptor classDescriptor;
 
-	public ObjectDefinition(String javaName, String factoryName, ClassDescriptor classDescriptor) {
+	public FactoryDefinition(String javaName, String factoryName, ClassDescriptor classDescriptor) {
 		this.javaName = javaName;
 		this.factoryName = factoryName;
 		this.classDescriptor = classDescriptor;

--- a/processor/src/main/java/org/openecard/robovm/processor/HeaderGenerator.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/HeaderGenerator.java
@@ -204,7 +204,7 @@ public class HeaderGenerator {
 		String iosType = classDescriptor.getIosType();
 		w.printf("static %s %s() __attribute__((deprecated(\"This factory method is obsolete. Use init method(s) instead.\"))) {%n",
 				iosType, factoryMethod);
-		w.printf("\textern %s* rvmInstantiateFramework(const char *className);%n", iosType);
+		w.printf("\textern %s rvmInstantiateFramework(const char *className);%n", iosType);
 		w.printf("\treturn rvmInstantiateFramework(\"%s\");%n", o.getJavaName());
 		w.println("}");
 		w.println();

--- a/processor/src/main/java/org/openecard/robovm/processor/HeaderGenerator.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/HeaderGenerator.java
@@ -108,6 +108,11 @@ public class HeaderGenerator {
 	}
 
 	private void writeProtocol(PrintWriter w, Type type, ClassDescriptor p) {
+		if (p.isDeprecated()) {
+			writeDeprecated(w);
+			w.println();
+		}
+
 		String objcName = p.getObjcName();
 		//w.printf("NS_SWIFT_NAME(%s)%n", objcName);
 		boolean isProtocol = p.getClassType() == ClassDescriptor.ClassType.Protocol;
@@ -179,7 +184,15 @@ public class HeaderGenerator {
 	private void writeMethod(PrintWriter w, MethodDescriptor md) {
 		w.print("-");
 		writeSignature(w, md);
+		if (md.isDeprecated()) {
+			w.print(" ");
+			writeDeprecated(w);
+		}
 		w.println(";");
+	}
+
+	private void writeDeprecated(PrintWriter w) {
+		w.print("__attribute__((deprecated))");
 	}
 
 	private void writeInitiatorFunction(PrintWriter w, FactoryDefinition o) {
@@ -188,7 +201,7 @@ public class HeaderGenerator {
 		if (factoryMethod == null) {
 			return;
 		}
-		w.printf("static %s %s() {%n", classDescriptor.getIosType(), factoryMethod);
+		w.printf("static %s %s() __attribute__((deprecated)) {%n", classDescriptor.getIosType(), factoryMethod);
 		w.printf("\textern %s* rvmInstantiateFramework(const char *className);%n", factoryMethod);
 		w.printf("\treturn rvmInstantiateFramework(\"%s\");%n", o.getJavaName());
 		w.println("}");
@@ -196,10 +209,8 @@ public class HeaderGenerator {
 	}
 
 	public void writeSignature(PrintWriter w, MethodDescriptor md) {
-		String macroModifier = md.isDeprecated()
-				? " DEPRECATED_ATTRIBUTE"
-				: "";
-		w.printf("(%s) %s%s", md.getReturnType().getIosType(), md.getName(), macroModifier);
+
+		w.printf("(%s) %s", md.getReturnType().getIosType(), md.getName());
 		boolean isFirstParameter = true;
 		for (MethodParameterDescriptor mp : md.getParameters()) {
 			final String effectiveParameterType = mp.getType().getIosType();

--- a/processor/src/main/java/org/openecard/robovm/processor/HeaderGenerator.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/HeaderGenerator.java
@@ -178,7 +178,7 @@ public class HeaderGenerator {
 
 	private void writeMethod(PrintWriter w, MethodDescriptor md) {
 		w.print("-");
-		md.printSignature(w);
+		writeSignature(w, md);
 		w.println(";");
 	}
 
@@ -193,6 +193,26 @@ public class HeaderGenerator {
 		w.printf("\treturn rvmInstantiateFramework(\"%s\");%n", o.getJavaName());
 		w.println("}");
 		w.println();
+	}
+
+	public void writeSignature(PrintWriter w, MethodDescriptor md) {
+		String macroModifier = md.isDeprecated()
+				? " DEPRECATED_ATTRIBUTE"
+				: "";
+		w.printf("(%s) %s%s", md.getReturnType().getIosType(), md.getName(), macroModifier);
+		boolean isFirstParameter = true;
+		for (MethodParameterDescriptor mp : md.getParameters()) {
+			final String effectiveParameterType = mp.getType().getIosType();
+			final String paramName = mp.getName();
+			if (isFirstParameter) {
+				w.printf(":(%s)%s", effectiveParameterType, paramName);
+				isFirstParameter = false;
+			} else {
+				char firstCharacter = Character.toUpperCase(paramName.charAt(0));
+				String remainingChar = paramName.substring(1);
+				w.printf(" with%s%s:(%s)%s", firstCharacter, remainingChar, effectiveParameterType, paramName);
+			}
+		}
 	}
 
 	private void writeEnum(PrintWriter w, EnumDescriptor e){

--- a/processor/src/main/java/org/openecard/robovm/processor/HeaderGenerator.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/HeaderGenerator.java
@@ -201,8 +201,10 @@ public class HeaderGenerator {
 		if (factoryMethod == null) {
 			return;
 		}
-		w.printf("static %s %s() __attribute__((deprecated)) {%n", classDescriptor.getIosType(), factoryMethod);
-		w.printf("\textern %s* rvmInstantiateFramework(const char *className);%n", factoryMethod);
+		String iosType = classDescriptor.getIosType();
+		w.printf("static %s %s() __attribute__((deprecated(\"This factory method is obsolete. Use init method(s) instead.\"))) {%n",
+				iosType, factoryMethod);
+		w.printf("\textern %s* rvmInstantiateFramework(const char *className);%n", iosType);
 		w.printf("\treturn rvmInstantiateFramework(\"%s\");%n", o.getJavaName());
 		w.println("}");
 		w.println();

--- a/processor/src/main/java/org/openecard/robovm/processor/HeaderGenerator.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/HeaderGenerator.java
@@ -37,17 +37,17 @@ import java.util.Map;
  */
 public class HeaderGenerator {
 
-	private final List<ObjectDefinition> objects;
+	private final List<FactoryDefinition> factoryDefs;
 	private final List<IncludeHeaderDefinition> includes;
 	private final TypeRegistry registry;
 	private final Types types;
 
 	public HeaderGenerator(
-			List<ObjectDefinition> objects,
+			List<FactoryDefinition> factoryDefs,
 			List<IncludeHeaderDefinition> includes,
 			TypeRegistry registry,
 			Types types) {
-		this.objects = objects;
+		this.factoryDefs = factoryDefs;
 		this.includes = includes;
 		this.registry = registry;
 		this.types = types;
@@ -78,7 +78,7 @@ public class HeaderGenerator {
 
 			w.println();
 
-			for (ObjectDefinition o : objects) {
+			for (FactoryDefinition o : factoryDefs) {
 				writeInitiatorFunction(w, o);
 			}
 		}
@@ -182,7 +182,7 @@ public class HeaderGenerator {
 		w.println(";");
 	}
 
-	private void writeInitiatorFunction(PrintWriter w, ObjectDefinition o) {
+	private void writeInitiatorFunction(PrintWriter w, FactoryDefinition o) {
 		String factoryMethod = o.getFactoryMethodName();
 		ClassDescriptor classDescriptor = o.getClassDescriptor();
 		if (factoryMethod == null) {

--- a/processor/src/main/java/org/openecard/robovm/processor/HeaderGenerator.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/HeaderGenerator.java
@@ -99,10 +99,18 @@ public class HeaderGenerator {
 	}
 
 	private void writeForwardDecl(PrintWriter w, ClassDescriptor p) {
+		String iosType;
+		switch(p.getClassType()) {
+			case Protocol:
+				iosType = "protocol";
+				break;
+			case Interface:
+				// XCode complains that the specification is invalid with forward declarations of interfaces.
+				return;
+			default:
+				throw new IllegalArgumentException("Unknown type: " + p.getClassType());
+		}
 		String objcName = p.getObjcName();
-		//w.printf("NS_SWIFT_NAME(%s)%n", objcName);
-		String iosType = p.getClassType() == ClassDescriptor.ClassType.Interface ?
-				"interface" : "protocol";
 
 		w.printf("@%s %s;%n", iosType, objcName);
 	}

--- a/processor/src/main/java/org/openecard/robovm/processor/KeywordDescriptor.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/KeywordDescriptor.java
@@ -1,0 +1,34 @@
+/** **************************************************************************
+ * Copyright (C) 2020 ecsec GmbH.
+ * All rights reserved.
+ * Contact: ecsec GmbH (info@ecsec.de)
+ *
+ * This file may be used in accordance with the terms and conditions
+ * contained in a signed written agreement between you and ecsec GmbH.
+ *
+ ************************************************************************** */
+package org.openecard.robovm.processor;
+
+/**
+ *
+ * @author Neil Crossley
+ */
+public class KeywordDescriptor implements TypeDescriptor {
+
+	private final String keyword;
+
+	public KeywordDescriptor(String keyword) {
+		this.keyword = keyword;
+	}
+
+	@Override
+	public String getIosType() {
+		return keyword;
+	}
+
+	@Override
+	public String marshaller() {
+		return null;
+	}
+
+}

--- a/processor/src/main/java/org/openecard/robovm/processor/LookupDeclarationDescriptor.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/LookupDeclarationDescriptor.java
@@ -25,6 +25,10 @@ public class LookupDeclarationDescriptor implements DeclarationDescriptor {
 		this.registry = registry;
 	}
 
+	public Type getType() {
+		return givenType;
+	}
+
 	@Override
 	public String getObjcName() {
 		return this.registry.asDeclaration(this.givenType).getObjcName();

--- a/processor/src/main/java/org/openecard/robovm/processor/MethodDescriptor.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/MethodDescriptor.java
@@ -39,18 +39,15 @@ public class MethodDescriptor {
 	private final TypeDescriptor returnType;
 	private final Symbol.MethodSymbol methodSymbol;
 	private final List<MethodParameterDescriptor> params;
-	private final boolean hasOverrideAnnotation;
 
 	public MethodDescriptor(
 			String name,
 			TypeDescriptor returnType,
-			Symbol.MethodSymbol methodSymbol,
-			boolean hasOverrideAnnotation
+			Symbol.MethodSymbol methodSymbol
 	) {
 		this.name = name;
 		this.returnType = returnType;
 		this.methodSymbol = methodSymbol;
-		this.hasOverrideAnnotation = hasOverrideAnnotation;
 		this.params = new ArrayList<>();
 	}
 
@@ -66,6 +63,10 @@ public class MethodDescriptor {
 		return Collections.unmodifiableList(params);
 	}
 
+	public boolean isStatic() {
+		return this.methodSymbol.isStatic();
+	}
+
 	public TypeDescriptor getReturnType() {
 		return returnType;
 	}
@@ -76,10 +77,6 @@ public class MethodDescriptor {
 
 	public boolean isDeprecated() {
 		return methodSymbol.isDeprecated();
-	}
-
-	public boolean hasOverrideAnnotation() {
-		return hasOverrideAnnotation;
 	}
 
 	public void printSignature(PrintWriter w) {

--- a/processor/src/main/java/org/openecard/robovm/processor/MethodDescriptor.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/MethodDescriptor.java
@@ -23,7 +23,6 @@
 package org.openecard.robovm.processor;
 
 import com.sun.tools.javac.code.Symbol;
-import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -77,26 +76,6 @@ public class MethodDescriptor {
 
 	public boolean isDeprecated() {
 		return methodSymbol.isDeprecated();
-	}
-
-	public void printSignature(PrintWriter w) {
-		String macroModifier = this.isDeprecated()
-				? " DEPRECATED_ATTRIBUTE"
-				: "";
-		w.printf("(%s) %s%s", this.getReturnType().getIosType(), this.getName(), macroModifier);
-		boolean isFirstParameter = true;
-		for (MethodParameterDescriptor mp : this.params) {
-			final String effectiveParameterType = mp.getType().getIosType();
-			final String paramName = mp.getName();
-			if (isFirstParameter) {
-				w.printf(":(%s)%s", effectiveParameterType, paramName);
-				isFirstParameter = false;
-			} else {
-				char firstCharacter = Character.toUpperCase(paramName.charAt(0));
-				String remainingChar = paramName.substring(1);
-				w.printf(" with%s%s:(%s)%s", firstCharacter, remainingChar, effectiveParameterType, paramName);
-			}
-		}
 	}
 
 	public String asSelector() {

--- a/processor/src/main/java/org/openecard/robovm/processor/MethodDescriptor.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/MethodDescriptor.java
@@ -22,6 +22,7 @@
 
 package org.openecard.robovm.processor;
 
+import com.sun.tools.javac.code.Symbol;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,12 +37,25 @@ public class MethodDescriptor {
 
 	private final String name;
 	private final TypeDescriptor returnType;
+	private final Symbol.MethodSymbol methodSymbol;
 	private final List<MethodParameterDescriptor> params;
+	private final boolean hasOverrideAnnotation;
 
-	public MethodDescriptor(String name, TypeDescriptor returnType) {
+	public MethodDescriptor(
+			String name,
+			TypeDescriptor returnType,
+			Symbol.MethodSymbol methodSymbol,
+			boolean hasOverrideAnnotation
+	) {
 		this.name = name;
 		this.returnType = returnType;
+		this.methodSymbol = methodSymbol;
+		this.hasOverrideAnnotation = hasOverrideAnnotation;
 		this.params = new ArrayList<>();
+	}
+
+	public Symbol.MethodSymbol getMethodSymbol() {
+		return methodSymbol;
 	}
 
 	public void addParam(MethodParameterDescriptor param) {
@@ -60,8 +74,19 @@ public class MethodDescriptor {
 		return name;
 	}
 
+	public boolean isDeprecated() {
+		return methodSymbol.isDeprecated();
+	}
+
+	public boolean hasOverrideAnnotation() {
+		return hasOverrideAnnotation;
+	}
+
 	public void printSignature(PrintWriter w) {
-		w.printf("(%s) %s", this.getReturnType().getIosType(), this.getName());
+		String macroModifier = this.isDeprecated()
+				? " DEPRECATED_ATTRIBUTE"
+				: "";
+		w.printf("(%s) %s%s", this.getReturnType().getIosType(), this.getName(), macroModifier);
 		boolean isFirstParameter = true;
 		for (MethodParameterDescriptor mp : this.params) {
 			final String effectiveParameterType = mp.getType().getIosType();

--- a/processor/src/main/java/org/openecard/robovm/processor/ObjectDefinition.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/ObjectDefinition.java
@@ -22,8 +22,6 @@
 
 package org.openecard.robovm.processor;
 
-import java.util.List;
-
 
 /**
  *
@@ -33,28 +31,20 @@ public class ObjectDefinition {
 
 	private final String javaName;
 	private final String factoryName;
-	private final ProtocolDescriptor protocol;
+	private final ClassDescriptor classDescriptor;
 
-	public ObjectDefinition(String javaName, String factoryName, ProtocolDescriptor protocol) {
+	public ObjectDefinition(String javaName, String factoryName, ClassDescriptor classDescriptor) {
 		this.javaName = javaName;
 		this.factoryName = factoryName;
-		this.protocol = protocol;
+		this.classDescriptor = classDescriptor;
 	}
 
 	public String getFactoryMethodName() {
 		return factoryName;
 	}
 
-	public <T extends DeclarationDescriptor> String getProtocolName(List<T> protocols) {
-		for (DeclarationDescriptor iface : this.protocol.getExtensions()) {
-			for (DeclarationDescriptor pd : protocols) {
-				if (iface.getObjcName().equals(pd.getObjcName())) {
-					return iface.getObjcName();
-				}
-			}
-		}
-
-		throw new RuntimeException("Missing ObjcProtocol on NSObject instance.");
+	public ClassDescriptor getClassDescriptor() {
+		return this.classDescriptor;
 	}
 
 	public String getJavaName() {

--- a/processor/src/main/java/org/openecard/robovm/processor/ObjectDefinition.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/ObjectDefinition.java
@@ -33,12 +33,12 @@ public class ObjectDefinition {
 
 	private final String javaName;
 	private final String factoryName;
-	private final List<String> ifaces;
+	private final ProtocolDescriptor protocol;
 
-	public ObjectDefinition(String javaName, String factoryName, List<String> ifaces) {
+	public ObjectDefinition(String javaName, String factoryName, ProtocolDescriptor protocol) {
 		this.javaName = javaName;
 		this.factoryName = factoryName;
-		this.ifaces = ifaces;
+		this.protocol = protocol;
 	}
 
 	public String getFactoryMethodName() {
@@ -46,10 +46,10 @@ public class ObjectDefinition {
 	}
 
 	public <T extends DeclarationDescriptor> String getProtocolName(List<T> protocols) {
-		for (String iface : ifaces) {
+		for (DeclarationDescriptor iface : this.protocol.getExtensions()) {
 			for (DeclarationDescriptor pd : protocols) {
-				if (iface.equals(pd.getObjcName())) {
-					return iface;
+				if (iface.getObjcName().equals(pd.getObjcName())) {
+					return iface.getObjcName();
 				}
 			}
 		}
@@ -60,5 +60,6 @@ public class ObjectDefinition {
 	public String getJavaName() {
 		return javaName;
 	}
+
 
 }

--- a/processor/src/main/java/org/openecard/robovm/processor/ProtocolDescriptor.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/ProtocolDescriptor.java
@@ -35,11 +35,11 @@ import java.util.List;
 public class ProtocolDescriptor implements TypeDescriptor, DeclarationDescriptor {
 
 	private final String objcName;
-	private final List<DeclarationDescriptor> extensions;
+	private final List<LookupDeclarationDescriptor> extensions;
 	private final List<MethodDescriptor> methods;
 	private final IosType type;
 
-	public ProtocolDescriptor(String ifaceName, List<DeclarationDescriptor> implementing, IosType type) {
+	public ProtocolDescriptor(String ifaceName, List<LookupDeclarationDescriptor> implementing, IosType type) {
 		this.objcName = ifaceName;
 		this.methods = new ArrayList<>();
 		this.extensions = implementing;
@@ -63,7 +63,7 @@ public class ProtocolDescriptor implements TypeDescriptor, DeclarationDescriptor
 		return Collections.unmodifiableList(methods);
 	}
 
-	public List<DeclarationDescriptor> getExtensions() {
+	public List<LookupDeclarationDescriptor> getExtensions() {
 		return Collections.unmodifiableList(extensions);
 	}
 

--- a/processor/src/main/java/org/openecard/robovm/processor/ProtocolDescriptor.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/ProtocolDescriptor.java
@@ -37,16 +37,22 @@ public class ProtocolDescriptor implements TypeDescriptor, DeclarationDescriptor
 	private final String objcName;
 	private final List<DeclarationDescriptor> extensions;
 	private final List<MethodDescriptor> methods;
+	private final IosType type;
 
-	public ProtocolDescriptor(String ifaceName, List<DeclarationDescriptor> implementing) {
+	public ProtocolDescriptor(String ifaceName, List<DeclarationDescriptor> implementing, IosType type) {
 		this.objcName = ifaceName;
 		this.methods = new ArrayList<>();
 		this.extensions = implementing;
+		this.type = type;
 	}
 
 	@Override
 	public String getObjcName() {
 		return objcName;
+	}
+
+	public IosType getType() {
+		return this.type;
 	}
 
 	public void addMethod(MethodDescriptor method) {
@@ -75,5 +81,10 @@ public class ProtocolDescriptor implements TypeDescriptor, DeclarationDescriptor
 	@Override
 	public String marshaller() {
 		return null;
+	}
+
+	public static enum IosType {
+		Interface,
+		Protocol;
 	}
 }

--- a/processor/src/main/java/org/openecard/robovm/processor/RobofaceProcessor.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/RobofaceProcessor.java
@@ -298,32 +298,10 @@ public class RobofaceProcessor extends AbstractProcessor {
 
 						final ObjectDefinition objDef = new ObjectDefinition(className, factoryName, protoDesc);
 
-
 						objDefs.add(objDef);
 
 						// add NSObject type to tree
 						ccd.extending = nsObjectExpression;
-
-						// add instance method
-						{
-
-							// define return type
-							JCTree.JCExpression returnType = tm.Type(nsObjectSymbol.type);
-							// define instance creation
-							JCTree.JCNewClass newSt = tm.NewClass(null, com.sun.tools.javac.util.List.nil(),
-									tm.Type(ccd.sym.asType()), com.sun.tools.javac.util.List.nil(), null);
-							JCTree.JCReturn newRet = tm.Return(newSt);
-							// define method block
-							JCTree.JCBlock body = tm.Block(0, com.sun.tools.javac.util.List.of(newRet));
-							// stick method together
-							JCTree.JCMethodDecl instMeth = tm.MethodDef(tm.Modifiers(Flags.PUBLIC | Flags.STATIC),
-									names.fromString("instantiate"),
-									returnType, com.sun.tools.javac.util.List.nil(), com.sun.tools.javac.util.List.nil(),
-									com.sun.tools.javac.util.List.nil(),
-									body, null);
-
-							ccd.defs = ccd.defs.append(instMeth);
-						}
 					}
 				}
 

--- a/processor/src/main/java/org/openecard/robovm/processor/RobofaceProcessor.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/RobofaceProcessor.java
@@ -49,7 +49,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.ProcessingEnvironment;
@@ -59,6 +58,7 @@ import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Modifier;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic;
@@ -98,6 +98,13 @@ public class RobofaceProcessor extends AbstractProcessor {
 	private List<ObjectDefinition> objDefs;
 	private TypeRegistry registry;
 
+	Symbol.ClassSymbol methodAttributeSym;
+	Symbol.ClassSymbol stringClazz;
+	Symbol.MethodSymbol methodSymbol;
+	Trees trees;
+	Names names;
+	TreeMaker tm;
+
 	@Override
 	public synchronized void init(ProcessingEnvironment processingEnv) {
 		super.init(processingEnv);
@@ -105,6 +112,14 @@ public class RobofaceProcessor extends AbstractProcessor {
 		firstPass = true;
 		objDefs = new ArrayList<>();
 		registry = new TypeRegistry(getInheritanceBlacklist(jcProcEnv));
+
+		methodAttributeSym = jcProcEnv.getElementUtils().getTypeElement("org.robovm.objc.annotation.Method");
+		stringClazz = jcProcEnv.getElementUtils().getTypeElement("java.lang.String");
+
+		trees = Trees.instance(processingEnv);
+		names = Names.instance(jcProcEnv.getContext());
+		methodSymbol = new Symbol.MethodSymbol(PARAMETER, names.fromString("selector"), stringClazz.type, methodAttributeSym.owner);
+		tm = TreeMaker.instance(jcProcEnv.getContext());
 	}
 
 	@Override
@@ -119,9 +134,7 @@ public class RobofaceProcessor extends AbstractProcessor {
 
 		Set<Type.ClassType> knownRobofaceInterfaces = new HashSet<>();
 
-		final Trees trees = Trees.instance(processingEnv);
 		final TreePathScanner<Object, CompilationUnitTree> enumScanner, ifaceScanner, objScanner, implScanner;
-		final Names names = Names.instance(jcProcEnv.getContext());
 
 		enumScanner = new TreePathScanner<Object, CompilationUnitTree>() {
 
@@ -155,7 +168,7 @@ public class RobofaceProcessor extends AbstractProcessor {
 			}
 		};
 
-		TreeMaker tm = TreeMaker.instance(jcProcEnv.getContext());
+
 		List<Map.Entry<TypeDescriptor, JCTree.JCModifiers>> methodDeclarations = new LinkedList<>();
 
 		// create ObjCProtocol type
@@ -163,10 +176,6 @@ public class RobofaceProcessor extends AbstractProcessor {
 		JCTree.JCExpression nsObjectProtocolExp = tm.Type(nsObjectProtocolSymbol.asType());
 
 		ifaceScanner = new TreePathScanner<Object, CompilationUnitTree>() {
-
-			Symbol.ClassSymbol methodAttributeSym = jcProcEnv.getElementUtils().getTypeElement("org.robovm.objc.annotation.Method");
-			Symbol.ClassSymbol stringClazz = jcProcEnv.getElementUtils().getTypeElement("java.lang.String");
-			Symbol.MethodSymbol methodSymbol = new Symbol.MethodSymbol(PARAMETER, names.fromString("selector"), stringClazz.type, methodAttributeSym.owner);
 
 			@Override
 			public Trees visitClass(ClassTree classTree, CompilationUnitTree unitTree) {
@@ -182,16 +191,13 @@ public class RobofaceProcessor extends AbstractProcessor {
 						knownRobofaceInterfaces.add((Type.ClassType)ccd.sym.type);
 
 						// record type information for header generation
-						final ProtocolDescriptor protoDesc = registry.createProtocolDescriptor(
-								ccd,
+						final ProtocolDescriptor protoDesc = registry.createProtocolDescriptor(ccd,
 								ProtocolDescriptor.IosType.Protocol);
 
 						// add ObjCProtocol type to tree
 						ccd.implementing = ccd.implementing.append(nsObjectProtocolExp);
 
-						annotateMethodsForSelectors(ccd, protoDesc, (tree) -> {
-							return tree.name.toString();
-						});
+						processMethods(ccd, protoDesc, methodDeclarations);
 
 					}
 				}
@@ -199,55 +205,12 @@ public class RobofaceProcessor extends AbstractProcessor {
 				return trees;
 			}
 
-			private void annotateMethodsForSelectors(final JCTree.JCClassDecl ccd, final ProtocolDescriptor protoDesc,
-					Function<JCTree.JCMethodDecl, String> nameResolver) {
-				// find methods in this interface and add @Method annotation
-				ccd.accept(new TreeTranslator() {
-					@Override
-					public <T extends JCTree> T translate(T tree) {
-						if (tree != null && (tree.getKind() == Tree.Kind.METHOD)) {
-							return super.translate(tree);
-						} else {
-							return tree;
-						}
-					}
-
-					@Override
-					public void visitMethodDef(JCTree.JCMethodDecl tree) {
-						super.visitMethodDef(tree);
-
-						// capture method definitions
-						final MethodDescriptor methodDescriptor = registry.createMethodDescriptor(
-								nameResolver.apply(tree),
-								tree.getReturnType().type);
-						protoDesc.addMethod(methodDescriptor);
-						methodDeclarations.add(new AbstractMap.SimpleImmutableEntry<>(methodDescriptor.getReturnType(), tree.getModifiers()));
-
-						for (JCTree.JCVariableDecl paramDecl : tree.params) {
-							Type parameterType = paramDecl.getType().type;
-
-							final MethodParameterDescriptor methodParamDescr = registry.createMethodParameterDescriptor(
-									paramDecl.name.toString(),
-									parameterType);
-							methodDescriptor.addParam(methodParamDescr);
-
-							methodDeclarations.add(new AbstractMap.SimpleImmutableEntry<>(methodParamDescr.getType(), paramDecl.getModifiers()));
-						}
-
-						// create @Method type
-						Pair<Symbol.MethodSymbol,Attribute> ds = new Pair<>(methodSymbol, new Attribute.Constant(stringClazz.type, methodDescriptor.asSelector()));
-						JCTree.JCAnnotation at = tm.Annotation(new Attribute.Compound(methodAttributeSym.asType(), com.sun.tools.javac.util.List.of(ds)));
-						tree.mods.annotations = tree.mods.annotations.append(at);
-
-						System.out.printf("Adding @Method annotation %s to method %s\n", at, tree.name);
-					}
-				});
-			}
 		};
 
 		// create ObjCProtocol type
 		Symbol.ClassSymbol nsObjectSymbol = jcProcEnv.getElementUtils().getTypeElement("org.robovm.apple.foundation.NSObject");
 		JCTree.JCExpression nsObjectExpression = tm.Type(nsObjectSymbol.asType());
+		Symbol.ClassSymbol javaObjectSymbol = jcProcEnv.getElementUtils().getTypeElement("java.lang.Object");
 
 		objScanner = new TreePathScanner<Object, CompilationUnitTree>() {
 
@@ -292,8 +255,7 @@ public class RobofaceProcessor extends AbstractProcessor {
 
 
 						// record type information for header generation
-						final ProtocolDescriptor protoDesc = registry.createProtocolDescriptor(
-								ccd,
+						final ProtocolDescriptor protoDesc = registry.createProtocolDescriptor(ccd,
 								ProtocolDescriptor.IosType.Interface);
 
 						final ObjectDefinition objDef = new ObjectDefinition(className, factoryName, protoDesc);
@@ -301,7 +263,11 @@ public class RobofaceProcessor extends AbstractProcessor {
 						objDefs.add(objDef);
 
 						// add NSObject type to tree
-						ccd.extending = nsObjectExpression;
+						if (ccd.extending == null || ccd.extending.type.equals(javaObjectSymbol.asType())) {
+							ccd.extending = nsObjectExpression;
+						}
+
+						processMethods(ccd, protoDesc, methodDeclarations);
 					}
 				}
 
@@ -310,7 +276,6 @@ public class RobofaceProcessor extends AbstractProcessor {
 		};
 
 		Types types = Types.instance(jcProcEnv.getContext());
-
 
 		Predicate<Type.ClassType> mustExtendNSObject = someType -> {
 			for (Type.ClassType knownRobofaceProtocolInterfaces : knownRobofaceInterfaces) {
@@ -419,7 +384,7 @@ public class RobofaceProcessor extends AbstractProcessor {
 					String headerPath = processingEnv.getOptions().getOrDefault(HEADER_PATH, HEADER_PATH_DEFAULT);
 					String headerName = processingEnv.getOptions().getOrDefault(HEADER_NAME, HEADER_NAME_DEFAULT);
 					List<IncludeHeaderDefinition> includeHeaders = this.getIncludeHeaders();
-					HeaderGenerator h = new HeaderGenerator(objDefs, includeHeaders, registry);
+					HeaderGenerator h = new HeaderGenerator(objDefs, includeHeaders, registry, types);
 					FileObject f = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT, headerPath, headerName);
 					h.writeHeader(f.openWriter());
 				} catch (IOException ex) {
@@ -433,6 +398,74 @@ public class RobofaceProcessor extends AbstractProcessor {
 
 		// claim annotation and prevent further processing
 		return true;
+	}
+
+	private void processMethods(
+			final JCTree.JCClassDecl ccd,
+			final ProtocolDescriptor protoDesc,
+			List<Map.Entry<TypeDescriptor, JCTree.JCModifiers>> methodDeclarations) {
+
+		// find methods in this interface and add @Method annotation
+		ccd.accept(new TreeTranslator() {
+			@Override
+			public <T extends JCTree> T translate(T tree) {
+				if (tree != null && (tree.getKind() == Tree.Kind.METHOD)) {
+					return super.translate(tree);
+				} else {
+					return tree;
+				}
+			}
+
+			@Override
+			public void visitMethodDef(JCTree.JCMethodDecl tree) {
+				super.visitMethodDef(tree);
+				if (!(tree.sym instanceof Symbol.MethodSymbol)) {
+					return;
+				}
+				JCTree.JCModifiers modifiers = tree.getModifiers();
+				Set<Modifier> flags = modifiers.getFlags();
+				if (flags.contains(Modifier.PRIVATE)
+						|| flags.contains(Modifier.PROTECTED)
+						|| flags.contains(Modifier.STATIC)) {
+					System.out.printf(" - Skipping method %s because it has the wrong flags: %s\n", tree.name, tree.mods.getFlags());
+					return;
+				}
+
+				MethodDescriptor methodDescriptor = registry.createMethod(tree);
+
+				if (methodDescriptor == null) {
+					return;
+				}
+				// capture method definitions
+
+				protoDesc.addMethod(methodDescriptor);
+				methodDeclarations.add(new AbstractMap.SimpleImmutableEntry<>(methodDescriptor.getReturnType(), tree.getModifiers()));
+
+				for (JCTree.JCVariableDecl paramDecl : tree.params) {
+					Type parameterType = paramDecl.getType().type;
+
+					final MethodParameterDescriptor methodParamDescr = registry.createMethodParameterDescriptor(
+							paramDecl.name.toString(),
+							parameterType);
+					methodDescriptor.addParam(methodParamDescr);
+
+					methodDeclarations.add(new AbstractMap.SimpleImmutableEntry<>(methodParamDescr.getType(), paramDecl.getModifiers()));
+				}
+
+				JCTree.JCAnnotation at = annotateWithMethodSelector(methodDescriptor, tree);
+
+				System.out.printf("Adding @Method annotation %s to method %s\n", at, tree.name);
+			}
+
+		});
+	}
+
+	private JCTree.JCAnnotation annotateWithMethodSelector(final MethodDescriptor methodDescriptor, JCTree.JCMethodDecl tree) {
+		// create @Method type
+		Pair<Symbol.MethodSymbol, Attribute> ds = new Pair<>(methodSymbol, new Attribute.Constant(stringClazz.type, methodDescriptor.asSelector()));
+		JCTree.JCAnnotation at = tm.Annotation(new Attribute.Compound(methodAttributeSym.asType(), com.sun.tools.javac.util.List.of(ds)));
+		tree.mods.annotations = tree.mods.annotations.append(at);
+		return at;
 	}
 
 	private void insertMarshallers(List<Map.Entry<TypeDescriptor, JCTree.JCModifiers>> methodDeclarations, TreeMaker tm) {

--- a/processor/src/main/java/org/openecard/robovm/processor/RobofaceProcessor.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/RobofaceProcessor.java
@@ -375,6 +375,7 @@ public class RobofaceProcessor extends AbstractProcessor {
 					FileObject f = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT, headerPath, headerName);
 					h.writeHeader(f.openWriter());
 				} catch (IOException ex) {
+					ex.printStackTrace();
 					processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Error writing native header: " + ex.getMessage());
 				}
 			}

--- a/processor/src/main/java/org/openecard/robovm/processor/RobofaceProcessor.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/RobofaceProcessor.java
@@ -255,6 +255,28 @@ public class RobofaceProcessor extends AbstractProcessor {
 
 						final FactoryDefinition factoryDef = new FactoryDefinition(className, factoryName, interfaceDesc);
 						factoryDefs.add(factoryDef);
+
+						if (factoryName != null)
+						{
+							// add instance method
+
+							// define return type
+							JCTree.JCExpression returnType = tm.Type(nsObjectSymbol.type);
+							// define instance creation
+							JCTree.JCNewClass newSt = tm.NewClass(null, com.sun.tools.javac.util.List.nil(),
+									tm.Type(ccd.sym.asType()), com.sun.tools.javac.util.List.nil(), null);
+							JCTree.JCReturn newRet = tm.Return(newSt);
+							// define method block
+							JCTree.JCBlock body = tm.Block(0, com.sun.tools.javac.util.List.of(newRet));
+							// stick method together
+							JCTree.JCMethodDecl instMeth = tm.MethodDef(tm.Modifiers(Flags.PUBLIC | Flags.STATIC),
+									names.fromString("instantiate"),
+									returnType, com.sun.tools.javac.util.List.nil(), com.sun.tools.javac.util.List.nil(),
+									com.sun.tools.javac.util.List.nil(),
+									body, null);
+
+							ccd.defs = ccd.defs.append(instMeth);
+						}
 					}
 				}
 

--- a/processor/src/main/java/org/openecard/robovm/processor/RobofaceProcessor.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/RobofaceProcessor.java
@@ -95,7 +95,7 @@ public class RobofaceProcessor extends AbstractProcessor {
 	private JavacProcessingEnvironment jcProcEnv;
 
 	private boolean firstPass;
-	private List<ObjectDefinition> objDefs;
+	private List<FactoryDefinition> factoryDefs;
 	private TypeRegistry registry;
 
 	Symbol.ClassSymbol methodAttributeSym;
@@ -110,7 +110,7 @@ public class RobofaceProcessor extends AbstractProcessor {
 		super.init(processingEnv);
 		jcProcEnv = (JavacProcessingEnvironment) processingEnv;
 		firstPass = true;
-		objDefs = new ArrayList<>();
+		factoryDefs = new ArrayList<>();
 		registry = new TypeRegistry(getInheritanceBlacklist(jcProcEnv));
 
 		methodAttributeSym = jcProcEnv.getElementUtils().getTypeElement("org.robovm.objc.annotation.Method");
@@ -245,16 +245,16 @@ public class RobofaceProcessor extends AbstractProcessor {
 						final ClassDescriptor interfaceDesc = registry.createClassDescriptor(ccd,
 								ClassDescriptor.ClassType.Interface);
 
-						final ObjectDefinition objDef = new ObjectDefinition(className, factoryName, interfaceDesc);
-
-						objDefs.add(objDef);
-
 						// add NSObject type to tree
 						if (ccd.extending == null || ccd.extending.type.equals(javaObjectSymbol.asType())) {
 							ccd.extending = nsObjectExpression;
 						}
 
 						processMethods(ccd, interfaceDesc, methodDeclarations);
+
+
+						final FactoryDefinition factoryDef = new FactoryDefinition(className, factoryName, interfaceDesc);
+						factoryDefs.add(factoryDef);
 					}
 				}
 
@@ -371,7 +371,7 @@ public class RobofaceProcessor extends AbstractProcessor {
 					String headerPath = processingEnv.getOptions().getOrDefault(HEADER_PATH, HEADER_PATH_DEFAULT);
 					String headerName = processingEnv.getOptions().getOrDefault(HEADER_NAME, HEADER_NAME_DEFAULT);
 					List<IncludeHeaderDefinition> includeHeaders = this.getIncludeHeaders();
-					HeaderGenerator h = new HeaderGenerator(objDefs, includeHeaders, registry, types);
+					HeaderGenerator h = new HeaderGenerator(factoryDefs, includeHeaders, registry, types);
 					FileObject f = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT, headerPath, headerName);
 					h.writeHeader(f.openWriter());
 				} catch (IOException ex) {

--- a/processor/src/main/java/org/openecard/robovm/processor/RobofaceProcessor.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/RobofaceProcessor.java
@@ -212,6 +212,9 @@ public class RobofaceProcessor extends AbstractProcessor {
 		JCTree.JCExpression nsObjectExpression = tm.Type(nsObjectSymbol.asType());
 		Symbol.ClassSymbol javaObjectSymbol = jcProcEnv.getElementUtils().getTypeElement("java.lang.Object");
 
+		Symbol.ClassSymbol customClassSymbol = jcProcEnv.getElementUtils().getTypeElement("org.robovm.objc.annotation.CustomClass");
+		JCTree.JCExpression customClassSymbolExp = tm.Type(customClassSymbol.asType());
+
 		objScanner = new TreePathScanner<Object, CompilationUnitTree>() {
 
 			@Override
@@ -252,9 +255,16 @@ public class RobofaceProcessor extends AbstractProcessor {
 
 						processMethods(ccd, interfaceDesc, methodDeclarations);
 
-
 						final FactoryDefinition factoryDef = new FactoryDefinition(className, factoryName, interfaceDesc);
 						factoryDefs.add(factoryDef);
+
+						JCTree.JCAnnotation customClassAnnotation = tm.Annotation(customClassSymbolExp,
+								com.sun.tools.javac.util.List.of(
+										tm.Assign(
+												tm.Ident(names.fromString("value")),
+												tm.Literal(ccd.getSimpleName().toString()))));
+
+						ccd.mods.annotations = ccd.mods.annotations.append(customClassAnnotation);
 
 						if (factoryName != null)
 						{

--- a/processor/src/main/java/org/openecard/robovm/processor/RobofaceProcessor.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/RobofaceProcessor.java
@@ -413,7 +413,8 @@ public class RobofaceProcessor extends AbstractProcessor {
 				JCTree.JCModifiers modifiers = tree.getModifiers();
 				Set<Modifier> flags = modifiers.getFlags();
 				if (flags.contains(Modifier.PRIVATE)
-						|| flags.contains(Modifier.PROTECTED)) {
+						|| flags.contains(Modifier.PROTECTED)
+						|| flags.contains(Modifier.STATIC)) {
 					System.out.printf(" - Skipping method %s because it has the wrong flags: %s\n", tree.name, tree.mods.getFlags());
 					return;
 				}

--- a/processor/src/main/java/org/openecard/robovm/processor/TypeRegistry.java
+++ b/processor/src/main/java/org/openecard/robovm/processor/TypeRegistry.java
@@ -103,7 +103,8 @@ public class TypeRegistry {
 		ClassDescriptor descriptor = new ClassDescriptor(
 				type.tsym.getSimpleName().toString(),
 				new LinkedList<>(),
-				ClassDescriptor.ClassType.Protocol);
+				ClassDescriptor.ClassType.Protocol,
+				false);
 		this.typeLookup.put(type, descriptor);
 		this.declarationLookup.put(type, descriptor);
 		return descriptor;
@@ -136,7 +137,12 @@ public class TypeRegistry {
 		final String simpleName = ccd.getSimpleName().toString();
 		List<LookupDeclarationDescriptor> inheritanceTypes = findInheritanceTypes(ccd, simpleName);
 
-		ClassDescriptor descriptor = new ClassDescriptor(simpleName, inheritanceTypes, type);
+		ClassDescriptor descriptor = new ClassDescriptor(
+				simpleName,
+				inheritanceTypes,
+				type,
+				ccd.sym.isDeprecated()
+		);
 		typeLookup.put(ccd.sym.type, descriptor);
 		protocols.put(ccd.sym.type, descriptor);
 		return descriptor;


### PR DESCRIPTION
Updates to RobiVM make the initialization of the framework with a call to `rvmInstantiateFramework` obsolete.

For improved integration in Apps, the emitted factory method is marked as deprecated in the generated header file. These changes also ensure that other deprecated methods/classes are also marked as deprecated in the generated header files.